### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/code/lambda/shared/shortener/adapter.js
+++ b/code/lambda/shared/shortener/adapter.js
@@ -1,6 +1,6 @@
 "use strict";
 var _ = require("lodash"),
-    uuid = require("node-uuid");
+    uuid = require("uuid");
 
 var CONST = {
     MODULE_NAME: "Shared/Shortener/Adapter/"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "intravenous": "^0.1.4-beta",
     "lodash": "^4.16.4",
     "nconf": "^0.8.4",
-    "node-uuid": "^1.4.7",
     "serverless": "^1.0.3",
     "shortid": "^2.2.6",
+    "uuid": "^3.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/spec/resolver/get/handlerSpec.js
+++ b/spec/resolver/get/handlerSpec.js
@@ -2,7 +2,7 @@
 
 var _ = require("lodash"),
     helper = require("../../helpers/helper.js"),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     shortid = require("shortid"),
     config = require("../../../code/lambda/shared/config"),
     fixtures = require("../../fixtures/resources-table.json"),

--- a/spec/shortener/create/handlerSpec.js
+++ b/spec/shortener/create/handlerSpec.js
@@ -3,7 +3,7 @@
 var _ = require("lodash"),
     helper = require("../../helpers/helper.js"),
     Index = require("../../../code/lambda/shortener/create/handler"),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     config = require("../../../code/lambda/shared/config"),
     AWS = require("aws-sdk");
 

--- a/spec/shortener/delete/handlerSpec.js
+++ b/spec/shortener/delete/handlerSpec.js
@@ -3,7 +3,7 @@
 var _ = require("lodash"),
     helper = require("../../helpers/helper.js"),
     Index = require("../../../code/lambda/shortener/delete/handler"),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     shortid = require("shortid"),
     config = require("../../../code/lambda/shared/config"),
     AWS = require("aws-sdk");

--- a/spec/shortener/list/handlerSpec.js
+++ b/spec/shortener/list/handlerSpec.js
@@ -2,7 +2,7 @@
 
 var _ = require("lodash"),
     helper = require("../../helpers/helper.js"),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     shortid = require("shortid"),
     config = require("../../../code/lambda/shared/config"),
     fixtures = require("../../fixtures/resources-table.json"),


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.